### PR TITLE
use HTTPS for CDN resource in example

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,7 +80,7 @@
         </div>
     </div>
 
-    <script src="http://cdnjs.cloudflare.com/ajax/libs/vue/1.0.21/vue.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/1.0.21/vue.min.js"></script>
     <script src="dist/fire-select.js"></script>
     <script src="script.js"></script>
 </body>


### PR DESCRIPTION
This is what I meant to resolve on #36 but forgot that github.io uses the `gh-pages` branch.
